### PR TITLE
cumsum(...,'reverse') unsupported in Octave.  Using cumsum(flip(...))…

### DIFF
--- a/+CIEtools/cielab_cylindrical_map.m
+++ b/+CIEtools/cielab_cylindrical_map.m
@@ -71,7 +71,7 @@ for p=2:size(L,1)
         [~,idx] = sort(cm(:,2));
         cm = cm(idx,:);
         % check for a common surface parity error
-        cm = cm(cumsum(cm(:,1),'reverse')*2-cm(:,1)==1,:);
+        cm = cm(cumsum(flip(cm(:,1)))*2-cm(:,1)==1,:);
         cylmap{p-1,q-1}=cm;
     end                 
 end

--- a/IntersectGamuts.m
+++ b/IntersectGamuts.m
@@ -38,8 +38,8 @@ end
 
 function [c]=intersect(a,b)
     % fix switched pairs of faces
-    a = a(cumsum(a(:,1),'reverse')*2-a(:,1)==1,:);
-    b = b(cumsum(b(:,1),'reverse')*2-b(:,1)==1,:);
+    a = a(cumsum(flip(a(:,1)))*2-a(:,1)==1,:);
+    b = b(cumsum(flip(b(:,1)))*2-b(:,1)==1,:);
     
     sa=size(a,1);
     sb=size(b,1);

--- a/PlotRings.m
+++ b/PlotRings.m
@@ -423,6 +423,14 @@ switch validatestring(p.Results.RefPrimaries,{'none','rgb','all'})
         nrefprims=6;
 end
 
+if ~isfield(gamut,'RGB')
+  nprims=0;
+end
+
+if ~isempty(refgamut) && ~isfield(refgamut,'RGB')
+  nrefprims=0;
+end
+
 ringorigin=strcmp(validateOrigin(p.Results.PrimaryOrigin),'ring');
 ringoffset=strcmp(validateOrigin(p.Results.PrimaryChromaOffset),'ring');
 rringorigin=strcmp(validateOrigin(p.Results.RefPrimaryOrigin),'ring');


### PR DESCRIPTION
… instead.  Also fixed an error where, in plotting rings from an intersection, the ringplot falls over because it cannot find the primary vectors (because there are no RGB values)

fixes #14 